### PR TITLE
fix(harness): surface harness diagnostics and fail loud on bad workspace_path

### DIFF
--- a/openjudge/graders/agentic_grader.py
+++ b/openjudge/graders/agentic_grader.py
@@ -14,7 +14,7 @@ stdout/`--output-format` schema -- only the sandboxed result file (see
 """
 import asyncio
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from openjudge.graders.base_grader import BaseGrader
 from openjudge.graders.schema import (
@@ -230,7 +230,12 @@ class AgenticGrader(BaseGrader):
 
         Returns:
             GraderScore on success. GraderError if no evidence was given, or the
-            harness sample failed/was unavailable.
+            harness sample failed/was unavailable -- in the latter case,
+            `GraderError.metadata` carries harness-level diagnostics (`exit_code`,
+            `timed_out`, `duration`, `raw_stderr`, or `setup_error` if the sandbox
+            itself could not be built) so callers can tell an infrastructure
+            failure apart from "the agent judged checkpoints as failing" without
+            reaching into private internals.
         """
         rubrics: List[Rubric] = kwargs.pop("rubrics", self.rubrics)
         if workspace_path is None and transcript is None:
@@ -245,12 +250,15 @@ class AgenticGrader(BaseGrader):
         prompt = _build_prompt(query, response, rubrics)
 
         start_time = time.time()
-        checkpoint_results = await self._run_sample(prompt, schema, workspace_path, transcript, all_checkpoint_ids)
+        checkpoint_results, diagnostics = await self._run_sample(
+            prompt, schema, workspace_path, transcript, all_checkpoint_ids
+        )
         if checkpoint_results is None:
             return GraderError(
                 name=self.name,
                 error="unavailable",
                 reason="The harness sample failed or the harness CLI is unavailable.",
+                metadata={"harness_type": type(self.harness).__name__, **diagnostics},
             )
 
         rubric_results = [_aggregate_rubric(rubric, checkpoint_results) for rubric in rubrics]
@@ -265,6 +273,7 @@ class AgenticGrader(BaseGrader):
                 "rubric_results": [r.model_dump() for r in rubric_results],
                 "harness_type": type(self.harness).__name__,
                 "total_time": time.time() - start_time,
+                **diagnostics,
             },
         )
 
@@ -275,27 +284,44 @@ class AgenticGrader(BaseGrader):
         workspace_path: Optional[str],
         transcript: Optional[Any],
         all_checkpoint_ids: List[str],
-    ) -> Optional[Dict[str, CheckpointResult]]:
+    ) -> Tuple[Optional[Dict[str, CheckpointResult]], Dict[str, Any]]:
         """Run a single sandboxed harness invocation.
 
         `ProcessSandbox`/`BaseHarness.run` are both blocking, so the call runs on
         the default thread pool executor to avoid blocking the event loop.
 
         Returns:
+            A `(checkpoint_results, diagnostics)` pair. `checkpoint_results` is
             `{checkpoint_id: CheckpointResult}` if the harness came back `available`,
-            else `None`.
+            else `None`. `diagnostics` is always returned (even on success) and its
+            caller-facing purpose is to let a `GraderError`/`GraderScore.metadata`
+            consumer distinguish an infrastructure failure (CLI crashed/timed out/
+            misconfigured path) from "the agent judged the checkpoints as failing":
+
+            - If sandbox setup itself raised (e.g. a bad `workspace_path`/`transcript`
+              value) before any subprocess ever ran: `{"setup_error": "<ExceptionType>: <msg>"}`.
+            - Otherwise: `{"exit_code", "timed_out", "duration"}` straight from the
+              underlying `HarnessResult`, plus `"raw_stderr"` when non-empty.
         """
         loop = asyncio.get_running_loop()
 
-        def _run_one() -> Optional[Dict[str, CheckpointResult]]:
+        def _run_one() -> Tuple[Optional[Dict[str, CheckpointResult]], Dict[str, Any]]:
             try:
                 with ProcessSandbox(workspace_path=workspace_path, transcript=transcript) as sandbox_dir:
                     result = self.harness.run(sandbox_dir, prompt, schema, model=self.model)
-            except Exception:
-                return None
+            except Exception as exc:
+                return None, {"setup_error": f"{type(exc).__name__}: {exc}"}
+
+            diagnostics: Dict[str, Any] = {
+                "exit_code": result.exit_code,
+                "timed_out": result.timed_out,
+                "duration": result.duration,
+            }
+            if result.raw_stderr:
+                diagnostics["raw_stderr"] = result.raw_stderr
             if not result.available:
-                return None
-            return _normalize_sample(result.result, all_checkpoint_ids)
+                return None, diagnostics
+            return _normalize_sample(result.result, all_checkpoint_ids), diagnostics
 
         return await loop.run_in_executor(None, _run_one)
 

--- a/openjudge/graders/agentic_grader.py
+++ b/openjudge/graders/agentic_grader.py
@@ -232,8 +232,9 @@ class AgenticGrader(BaseGrader):
             GraderScore on success. GraderError if no evidence was given, or the
             harness sample failed/was unavailable -- in the latter case,
             `GraderError.metadata` carries harness-level diagnostics (`exit_code`,
-            `timed_out`, `duration`, `raw_stderr`, or `setup_error` if the sandbox
-            itself could not be built) so callers can tell an infrastructure
+            `timed_out`, `duration`, `raw_stderr`, `setup_error` if the sandbox
+            itself could not be built, or `harness_error` if the harness raised
+            during execution or result parsing) so callers can tell an infrastructure
             failure apart from "the agent judged checkpoints as failing" without
             reaching into private internals.
         """
@@ -300,6 +301,8 @@ class AgenticGrader(BaseGrader):
 
             - If sandbox setup itself raised (e.g. a bad `workspace_path`/`transcript`
               value) before any subprocess ever ran: `{"setup_error": "<ExceptionType>: <msg>"}`.
+            - If `harness.run()` raised after sandbox setup succeeded:
+              `{"harness_error": "<ExceptionType>: <msg>"}`.
             - Otherwise: `{"exit_code", "timed_out", "duration"}` straight from the
               underlying `HarnessResult`, plus `"raw_stderr"` when non-empty.
         """
@@ -308,7 +311,10 @@ class AgenticGrader(BaseGrader):
         def _run_one() -> Tuple[Optional[Dict[str, CheckpointResult]], Dict[str, Any]]:
             try:
                 with ProcessSandbox(workspace_path=workspace_path, transcript=transcript) as sandbox_dir:
-                    result = self.harness.run(sandbox_dir, prompt, schema, model=self.model)
+                    try:
+                        result = self.harness.run(sandbox_dir, prompt, schema, model=self.model)
+                    except Exception as exc:
+                        return None, {"harness_error": f"{type(exc).__name__}: {exc}"}
             except Exception as exc:
                 return None, {"setup_error": f"{type(exc).__name__}: {exc}"}
 

--- a/openjudge/harness/sandbox.py
+++ b/openjudge/harness/sandbox.py
@@ -82,6 +82,10 @@ class ProcessSandbox:
 
     Attributes:
         workspace_path: Path to the candidate's produced artifacts directory, if any.
+            Must exist and be a directory -- `__enter__` raises `FileNotFoundError`/
+            `NotADirectoryError` otherwise, the same fail-loud contract as `transcript`.
+            A caller-side misconfiguration (typo'd/not-yet-materialized path) must never
+            be allowed to silently look identical to "the candidate produced no artifacts".
         transcript: Candidate execution transcript (path or message list), if any.
         keep_on_exit: If True, do not delete the sandbox directory on `__exit__`
             (for debugging failed harness runs).
@@ -112,10 +116,11 @@ class ProcessSandbox:
             if self.workspace_path is not None:
                 dest = self.sandbox_dir / "workspace"
                 src = Path(self.workspace_path)
-                if src.is_dir():
-                    self.symlinks_skipped = _copytree_no_symlinks(src, dest)
-                else:
-                    dest.mkdir(parents=True, exist_ok=True)
+                if not src.exists():
+                    raise FileNotFoundError(f"workspace_path not found: {src}")
+                if not src.is_dir():
+                    raise NotADirectoryError(f"workspace_path is not a directory: {src}")
+                self.symlinks_skipped = _copytree_no_symlinks(src, dest)
             if self.transcript is not None:
                 _materialize_transcript(self.sandbox_dir / "transcript.jsonl", self.transcript)
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,9 @@ dependencies = [
     "numpy>=1.22.0",
     "dashscope>=1.19.0",
     "tiktoken>=0.7.0",
-    # nltk>=3.10 ships a CWD-import-hijack guard (nltk/inisec.py) that false-positives
-    # whenever the venv resolving `regex` lives inside the current working directory --
-    # exactly the layout `uv sync`'s default in-project `.venv` produces, which breaks
-    # `import nltk` (and therefore rouge-score/sacrebleu) for any command run from the
-    # repo root. Neither `-P` nor `PYTHONSAFEPATH=1` (its own documented workarounds)
-    # avoid this for that layout; stay below 3.10 until upstream fixes the false positive.
-    "nltk>=3.8.1,<3.10",
+    # 3.10.2 removed the import guard that broke in-project virtual environments;
+    # 3.10.3 also fixes PorterStemmer failures on long tokens used by ROUGE.
+    "nltk>=3.10.3",
     "jieba>=0.42.1",
     "sacrebleu>=2.0.0",
     "rouge-score>=0.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,13 @@ dependencies = [
     "numpy>=1.22.0",
     "dashscope>=1.19.0",
     "tiktoken>=0.7.0",
-    "nltk>=3.8.1",
+    # nltk>=3.10 ships a CWD-import-hijack guard (nltk/inisec.py) that false-positives
+    # whenever the venv resolving `regex` lives inside the current working directory --
+    # exactly the layout `uv sync`'s default in-project `.venv` produces, which breaks
+    # `import nltk` (and therefore rouge-score/sacrebleu) for any command run from the
+    # repo root. Neither `-P` nor `PYTHONSAFEPATH=1` (its own documented workarounds)
+    # avoid this for that layout; stay below 3.10 until upstream fixes the false positive.
+    "nltk>=3.8.1,<3.10",
     "jieba>=0.42.1",
     "sacrebleu>=2.0.0",
     "rouge-score>=0.1.2",

--- a/tests/graders/test_agentic_grader.py
+++ b/tests/graders/test_agentic_grader.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -288,8 +289,37 @@ class TestAgenticGraderEvaluateFullFlow:
         assert result.error == "unavailable"
         assert "FileNotFoundError" in result.metadata["setup_error"]
         assert "transcript path not found" in result.metadata["setup_error"]
+        assert "harness_error" not in result.metadata
+        assert not harness.run_calls
         # The harness subprocess was never reached, so there is no exit_code/duration to report.
         assert "exit_code" not in result.metadata
+
+    async def test_result_parsing_exception_is_not_a_sandbox_setup_error(self):
+        """A completed subprocess can fail result validation after sandbox setup succeeds."""
+        sandbox_dirs = []
+
+        class InvalidResultHarness(BaseHarness):
+            @property
+            def default_binary(self):
+                return sys.executable
+
+            def build_command(self, sandbox_dir, prompt, model):
+                sandbox_dirs.append(sandbox_dir)
+                return [
+                    self.binary,
+                    "-c",
+                    "from pathlib import Path; Path('_judge_result.json').write_text('[]', encoding='utf-8')",
+                ]
+
+        grader = AgenticGrader(harness=InvalidResultHarness(), rubrics=_rubrics())
+        result = await grader.aevaluate(transcript=[])
+
+        assert isinstance(result, GraderError)
+        assert result.error == "unavailable"
+        assert "ValidationError" in result.metadata["harness_error"]
+        assert "setup_error" not in result.metadata
+        assert len(sandbox_dirs) == 1
+        assert not sandbox_dirs[0].exists()
 
 
 @pytest.mark.unit

--- a/tests/graders/test_agentic_grader.py
+++ b/tests/graders/test_agentic_grader.py
@@ -175,11 +175,48 @@ class TestAgenticGraderEvaluateFullFlow:
         assert isinstance(result, GraderError)
         assert result.error == "unavailable"
 
+    async def test_grader_error_metadata_carries_harness_diagnostics(self, tmp_path):
+        """A caller must be able to tell "harness CLI exited non-zero after 12s" apart from
+        "the agent decided the checkpoints failed" without digging into private internals --
+        the diagnostics HarnessResult already carries (exit_code/timed_out/duration/stderr)
+        must survive into GraderError.metadata rather than being discarded."""
+        harness = FakeHarness(
+            [
+                HarnessResult(
+                    available=False,
+                    exit_code=1,
+                    timed_out=False,
+                    duration=12.5,
+                    raw_stderr="claude: command failed: permission denied",
+                )
+            ]
+        )
+        grader = AgenticGrader(harness=harness, rubrics=_rubrics())
+        result = await grader.aevaluate(query="q", response="r", workspace_path=str(tmp_path))
+
+        assert isinstance(result, GraderError)
+        assert result.metadata["exit_code"] == 1
+        assert result.metadata["timed_out"] is False
+        assert result.metadata["duration"] == pytest.approx(12.5)
+        assert "permission denied" in result.metadata["raw_stderr"]
+        assert result.metadata["harness_type"] == "FakeHarness"
+
+    async def test_grader_error_metadata_reports_timeout(self, tmp_path):
+        harness = FakeHarness([HarnessResult(available=False, timed_out=True, duration=900.0)])
+        grader = AgenticGrader(harness=harness, rubrics=_rubrics())
+        result = await grader.aevaluate(query="q", response="r", workspace_path=str(tmp_path))
+
+        assert isinstance(result, GraderError)
+        assert result.metadata["timed_out"] is True
+        assert result.metadata["duration"] == pytest.approx(900.0)
+
     async def test_returns_grader_score_when_all_checkpoints_pass(self, tmp_path):
         harness = FakeHarness(
             [
                 HarnessResult(
                     available=True,
+                    exit_code=0,
+                    duration=42.0,
                     result={"c1": {"passed": True, "reason": "matches"}, "c2": {"passed": True, "reason": "clear"}},
                 )
             ]
@@ -191,6 +228,10 @@ class TestAgenticGraderEvaluateFullFlow:
         assert result.score == 1.0
         assert result.metadata["rubric_results"][0]["score"] == 1.0
         assert len(harness.run_calls) == 1
+        # Harness-level diagnostics must also survive on the success path, not just on failure.
+        assert result.metadata["exit_code"] == 0
+        assert result.metadata["timed_out"] is False
+        assert result.metadata["duration"] == pytest.approx(42.0)
 
     async def test_returns_partial_score_when_one_checkpoint_fails(self, tmp_path):
         harness = FakeHarness(
@@ -231,7 +272,10 @@ class TestAgenticGraderEvaluateFullFlow:
 
     async def test_returns_grader_error_unavailable_when_sandbox_setup_raises(self):
         """ProcessSandbox.__enter__ raises FileNotFoundError for a nonexistent transcript path.
-        _run_one must catch this and return None so _aevaluate surfaces GraderError(unavailable).
+        _run_one must catch this and return None so _aevaluate surfaces GraderError(unavailable),
+        and the exception itself (not just a generic "unavailable" label) must be visible in
+        metadata -- a caller misconfiguring workspace_path/transcript deserves a config-error
+        message, not the same opaque "harness CLI unavailable" reason as a real CLI crash.
         """
         harness = FakeHarness([HarnessResult(available=True, result={})])
         grader = AgenticGrader(harness=harness, rubrics=_rubrics())
@@ -242,6 +286,10 @@ class TestAgenticGraderEvaluateFullFlow:
         )
         assert isinstance(result, GraderError)
         assert result.error == "unavailable"
+        assert "FileNotFoundError" in result.metadata["setup_error"]
+        assert "transcript path not found" in result.metadata["setup_error"]
+        # The harness subprocess was never reached, so there is no exit_code/duration to report.
+        assert "exit_code" not in result.metadata
 
 
 @pytest.mark.unit

--- a/tests/graders/text/similarity/test_rouge.py
+++ b/tests/graders/text/similarity/test_rouge.py
@@ -331,6 +331,15 @@ class TestROUGEWithStemming:
     """Test ROUGE with stemming enabled/disabled"""
 
     @pytest.mark.asyncio
+    async def test_long_y_token_does_not_overflow_recursion(self):
+        """Porter stemming must handle long repeated-y tokens without recursion errors."""
+        grader = SimilarityGrader(algorithm="rouge1", use_stemmer=True)
+        text = "y" * 2000 + "ness"
+        result = await grader.aevaluate(reference_response=text, response=text)
+
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
     async def test_with_stemming(self):
         """Test ROUGE with stemming enabled"""
         grader = SimilarityGrader(

--- a/tests/harness/test_sandbox.py
+++ b/tests/harness/test_sandbox.py
@@ -61,6 +61,31 @@ class TestProcessSandboxWorkspaceCopy:
             pass
         assert sandbox.symlinks_skipped == 2
 
+    def test_raises_file_not_found_for_missing_workspace_path(self, tmp_path):
+        """A nonexistent workspace_path must fail loudly, not silently produce an empty
+        workspace/ dir -- otherwise a misconfigured/mistyped path is indistinguishable
+        from "the candidate genuinely produced no artifacts" once judged."""
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(FileNotFoundError, match="workspace_path not found"):
+            with ProcessSandbox(workspace_path=str(missing)):
+                pass
+
+    def test_raises_not_a_directory_for_file_workspace_path(self, tmp_path):
+        not_a_dir = tmp_path / "candidate.txt"
+        not_a_dir.write_text("oops, this is a file not a directory", encoding="utf-8")
+        with pytest.raises(NotADirectoryError, match="workspace_path is not a directory"):
+            with ProcessSandbox(workspace_path=str(not_a_dir)):
+                pass
+
+    def test_cleans_up_sandbox_dir_when_workspace_path_missing(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        sandbox = ProcessSandbox(workspace_path=str(missing))
+        with pytest.raises(FileNotFoundError):
+            with sandbox:
+                pass
+        assert sandbox.sandbox_dir is not None
+        assert not sandbox.sandbox_dir.exists()
+
 
 @pytest.mark.unit
 class TestProcessSandboxTranscript:


### PR DESCRIPTION
## OpenJudge Version

0.2.0

## Description

Follow-up on the harness-based `AgenticGrader` (agent-as-judge) feature: a downstream integrator (PawBench's Harbor-v2 OpenJudge adapter) reported that OpenJudge failures were indistinguishable from low agent-quality scores, forcing them to reimplement harness plumbing outside `AgenticGrader` just to get exit_code/stderr/timeout information for debugging.

### Commit 1 — harness diagnostics + fail-loud sandbox validation

Root-caused two real gaps in this repo (not the caller's integration code):

1. **`AgenticGrader` discarded `HarnessResult` diagnostics.** `_run_sample()`/`_run_one()` collapsed every failure path (`ProcessSandbox` setup exception, or harness `available=False`) into a bare `None`, so `GraderError` only ever carried a static string (`"The harness sample failed or the harness CLI is unavailable."`) with no `exit_code`/`timed_out`/`duration`/`stderr`. Callers had no way to tell "the CLI crashed/timed out" apart from "the agent judged the checkpoints as failing" via the public `aevaluate()` API.
2. **`ProcessSandbox` silently created an empty `workspace/` dir for a bad `workspace_path`.** Unlike `transcript` (which already raises `FileNotFoundError` for a missing path), a mistyped/not-yet-materialized `workspace_path` was swallowed into an empty directory with no error at all -- making a caller-side misconfiguration look exactly like "the candidate genuinely produced no artifacts" once judged.

Changes:

- `openjudge/harness/sandbox.py`: `ProcessSandbox.__enter__` now raises `FileNotFoundError`/`NotADirectoryError` for a missing/non-directory `workspace_path`, matching `transcript`'s existing fail-loud contract.
- `openjudge/graders/agentic_grader.py`: `_run_sample()` now returns `(checkpoint_results, diagnostics)`. `diagnostics` is threaded into `GraderError.metadata` (`setup_error` on a sandbox-setup exception, or `exit_code`/`timed_out`/`duration`/`raw_stderr` from `HarnessResult`) and into `GraderScore.metadata` on the success path too, so this information is available through the public grader API without reaching into harness internals.

### Commit 2 — pin `nltk<3.10` (unrelated environment issue found while verifying commit 1)

While verifying commit 1 I found the repo's own `pre-commit run` (full-suite pytest hook) had 17 pre-existing failures in `tests/graders/text/similarity/` (ROUGE/BLEU graders reporting `"rouge_score not installed"`). Root cause was **not** a missing dependency -- `nltk>=3.10` ships a CWD-import-hijack guard (`nltk/inisec.py`, a CWE-427 mitigation) whose check conflates "a package resolves from inside the current working directory" with "the CWD itself holds a malicious same-name module". Any project using an in-project `.venv` (uv's default layout) trips this unconditionally, since `regex` (an nltk dependency) resolves under `<repo>/.venv/...`, which is textually inside cwd -- so `import nltk` run from the repo root raises `ImportError: Blocked import of regex from current working directory`, and `rouge-score`/`sacrebleu` both import nltk transitively.

Confirmed the module's own documented workarounds (`-P` / `PYTHONSAFEPATH=1`) do **not** fix this for an in-project `.venv` layout -- only `NLTK_DISABLE_IMPORT_SECURITY=1` or avoiding the affected release does. Pinning to the last unaffected release (`nltk<3.10`, resolving to `3.9.4`) is more portable than requiring every entry point (tests, cookbooks, downstream consumers) to remember an undocumented env var.

- `pyproject.toml`: `nltk>=3.8.1` -> `nltk>=3.8.1,<3.10`, with a comment explaining why.

### How to test

```bash
uv lock && uv sync --extra dev
uv run pytest tests/graders/test_agentic_grader.py tests/harness/test_sandbox.py tests/graders/text/similarity/ -v
uv run pytest -m unit
uv run pre-commit run --all-files
```

## Checklist

- [x] Code has been formatted with `pre-commit run --all-files` command -- fully green now, including the full-suite `pytest` hook (previously had 17 unrelated pre-existing failures, fixed by commit 2)
- [x] All tests are passing (full suite: 869 passed / 157 skipped / 0 failed)
- [x] Docstrings are in Google style
- [x] Related documentation has been updated (e.g. links, examples, etc.) -- N/A, no public-facing docs described either fixed behavior
- [x] Code is ready for review