### PR TITLE
fix(analyzer): guard CorrelationAnalyzer against NaN on zero-variance input

### DIFF
--- a/openjudge/analyzer/validation/correlation_analyzer.py
+++ b/openjudge/analyzer/validation/correlation_analyzer.py
@@ -147,6 +147,19 @@ class CorrelationAnalyzer(BaseValidationAnalyzer):
                 # Calculate Pearson correlation coefficient
                 correlation_matrix = np.corrcoef(predicted_scores, ground_truth_labels)
                 correlation_score = correlation_matrix[0, 1]
+
+                # Handle NaN case - occurs when one array has zero variance (all values identical)
+                if np.isnan(correlation_score):
+                    # If all values in either array are identical, perfect correlation if both
+                    # arrays have constant values that match each other
+                    scores_unique = len(set(predicted_scores)) == 1
+                    labels_unique = len(set(ground_truth_labels)) == 1
+                    if scores_unique and labels_unique and predicted_scores[0] == ground_truth_labels[0]:
+                        correlation_score = 1.0
+                    else:
+                        # If one array has variance and the other doesn't, they're uncorrelated
+                        correlation_score = 0.0
+
                 explanation = f"Correlation based on {len(predicted_scores)} data points: {correlation_score:.4f}"
             except Exception as e:
                 correlation_score = 0.0

--- a/tests/analyzer/validation/test_correlation_analyzer.py
+++ b/tests/analyzer/validation/test_correlation_analyzer.py
@@ -113,6 +113,72 @@ class TestCorrelationAnalyzer:
         assert "explanation" in result.metadata
         assert "No data or grader results provided for correlation calculation" in result.metadata["explanation"]
 
+    def test_analyze_zero_variance_scores(self):
+        """Test analyze method when predicted scores are all identical (zero variance)."""
+        dataset = [
+            {"label": 0.8},
+            {"label": 0.6},
+            {"label": 0.9},
+        ]
+
+        grader_results = [
+            GraderScore(name="test", score=1.0, reason="Score 1"),
+            GraderScore(name="test", score=1.0, reason="Score 2"),
+            GraderScore(name="test", score=1.0, reason="Score 3"),
+        ]
+
+        analyzer = CorrelationAnalyzer()
+        result = analyzer.analyze(dataset, grader_results, label_path="label")
+
+        assert isinstance(result, CorrelationAnalysisResult)
+        assert result.correlation == 0.0
+        assert result.correlation == result.correlation  # not NaN
+        assert "explanation" in result.metadata
+        assert "Correlation based on 3 data points: 0.0000" in result.metadata["explanation"]
+
+    def test_analyze_zero_variance_labels(self):
+        """Test analyze method when ground truth labels are all identical (zero variance)."""
+        dataset = [
+            {"label": 1.0},
+            {"label": 1.0},
+            {"label": 1.0},
+        ]
+
+        grader_results = [
+            GraderScore(name="test", score=0.1, reason="Score 1"),
+            GraderScore(name="test", score=0.5, reason="Score 2"),
+            GraderScore(name="test", score=0.9, reason="Score 3"),
+        ]
+
+        analyzer = CorrelationAnalyzer()
+        result = analyzer.analyze(dataset, grader_results, label_path="label")
+
+        assert isinstance(result, CorrelationAnalysisResult)
+        assert result.correlation == 0.0
+        assert result.correlation == result.correlation  # not NaN
+        assert "explanation" in result.metadata
+        assert "Correlation based on 3 data points: 0.0000" in result.metadata["explanation"]
+
+    def test_analyze_zero_variance_scores_and_labels_matching(self):
+        """Test analyze method when both scores and labels are identical and equal to each other."""
+        dataset = [
+            {"label": 1.0},
+            {"label": 1.0},
+        ]
+
+        grader_results = [
+            GraderScore(name="test", score=1.0, reason="Score 1"),
+            GraderScore(name="test", score=1.0, reason="Score 2"),
+        ]
+
+        analyzer = CorrelationAnalyzer()
+        result = analyzer.analyze(dataset, grader_results, label_path="label")
+
+        assert isinstance(result, CorrelationAnalysisResult)
+        assert result.correlation == 1.0
+        assert "explanation" in result.metadata
+        assert "Correlation based on 2 data points: 1.0000" in result.metadata["explanation"]
+
     def test_analyze_insufficient_data(self):
         """Test analyze method with insufficient data."""
         # Prepare test data with only one sample (insufficient for correlation)


### PR DESCRIPTION
## Description

`CorrelationAnalyzer.analyze()` computes `np.corrcoef(predicted_scores, ground_truth_labels)` and returns the result directly. When either array has zero variance (all values identical), `np.corrcoef` returns `NaN` without raising, so the existing `except Exception` guard never fires. `correlation_score` silently ends up `NaN`, and the explanation string reports it as-is.

This is reachable on real data here: several of the repo's own graders (for example `ToolCallSuccessGrader`, `ActionAlignmentGrader`) return strict binary 0.0/1.0 scores, so an "easy" validation batch where every sample scores 1.0 collapses `predicted_scores` to a constant array and triggers this.

Root cause: `openjudge/analyzer/validation/correlation_analyzer.py`, `CorrelationAnalyzer.analyze()`, the `np.corrcoef` branch.

## Fix

Add an `np.isnan` guard mirroring the one already merged for the same `np.corrcoef` pattern in the sibling `ConsistencyAnalyzer` (#61): if both arrays are constant and equal, correlation is 1.0 (perfect agreement); otherwise 0.0 (uncorrelated).

## Verification

- Reproduced on HEAD before the fix, in a clean `python:3.12-slim` Docker container: calling `CorrelationAnalyzer.analyze()` through its public API with constant scores, and separately with constant labels, both returned `NaN` with `math.isnan(result.correlation) == True`.
- Added `test_analyze_zero_variance_scores`, `test_analyze_zero_variance_labels`, and `test_analyze_zero_variance_scores_and_labels_matching` to `tests/analyzer/validation/test_correlation_analyzer.py`, covering the two collapsing branches and the constant-and-equal branch.
- Ran the full `test_correlation_analyzer.py` suite (9 tests) in the same clean container: all pass after the fix, and the three new tests fail before it.
- Did not check the calling code that consumes `CorrelationAnalysisResult` downstream for behavior on a `correlation` of exactly 0.0 in the previously-NaN case, since 0.0 was already a valid non-error return value in this method (see `test_analyze_empty_data`).
