### PR TITLE
fix(models): give QwenVLModel a timeout, wired to DashScope's request_timeout

### DIFF
--- a/openjudge/models/qwen_vl_model.py
+++ b/openjudge/models/qwen_vl_model.py
@@ -49,6 +49,7 @@ class QwenVLModel(BaseChatModel):
         temperature: float = 0.1,
         top_p: float = 0.9,
         max_tokens: int = 2000,
+        timeout: Optional[float] = None,
     ):
         """
         Initialize Qwen VL API client
@@ -59,6 +60,8 @@ class QwenVLModel(BaseChatModel):
             temperature: Sampling temperature
             top_p: Nucleus sampling
             max_tokens: Maximum tokens to generate
+            timeout: Request timeout in seconds (defaults to the DashScope
+                SDK's own default of 300s when not set)
         """
         super().__init__(model=model, stream=False)
 
@@ -72,6 +75,7 @@ class QwenVLModel(BaseChatModel):
         self.temperature = temperature
         self.top_p = top_p
         self.max_tokens = max_tokens
+        self.timeout = timeout
 
         # Cost tracking
         self._total_requests = 0
@@ -151,15 +155,22 @@ class QwenVLModel(BaseChatModel):
         messages = self._format_messages(content, system_prompt)
 
         # Call API
+        call_kwargs: Dict[str, Any] = {
+            "api_key": self.api_key,
+            "model": self.model,
+            "messages": messages,
+            "temperature": self.temperature,
+            "top_p": self.top_p,
+            "max_length": self.max_tokens,
+        }
+        if self.timeout is not None:
+            # DashScope reads the socket timeout from `request_timeout`;
+            # a `timeout=` kwarg is accepted but dropped into the request
+            # body unused, so this is not a naming choice.
+            call_kwargs["request_timeout"] = self.timeout
+
         try:
-            response = MultiModalConversation.call(
-                api_key=self.api_key,
-                model=self.model,
-                messages=messages,
-                temperature=self.temperature,
-                top_p=self.top_p,
-                max_length=self.max_tokens,
-            )
+            response = MultiModalConversation.call(**call_kwargs)
 
             self._total_requests += 1
 

--- a/tests/models/test_qwen_vl_model.py
+++ b/tests/models/test_qwen_vl_model.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for QwenVLModel."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openjudge.models.qwen_vl_model import QwenVLModel
+
+
+def _fake_response(text: str = "OK"):
+    response = MagicMock()
+    response.status_code = 200
+    response.message = ""
+    response.output.choices = [MagicMock()]
+    response.output.choices[0].message.content = [{"text": text}]
+    return response
+
+
+@pytest.mark.unit
+class TestQwenVLModelTimeout:
+    """Test cases for QwenVLModel's timeout handling."""
+
+    @pytest.mark.parametrize(
+        "init_kwargs, expect_request_timeout",
+        [
+            ({"timeout": 5.0}, 5.0),
+            ({}, None),
+            ({"timeout": None}, None),
+        ],
+        ids=["with_timeout", "defaults", "explicit_none"],
+    )
+    @patch("openjudge.models.qwen_vl_model.MultiModalConversation")
+    def test_generate_forwards_request_timeout(
+        self,
+        mock_conversation,
+        init_kwargs,
+        expect_request_timeout,
+    ):
+        """timeout=N must reach DashScope as request_timeout=N, never as timeout=N."""
+        mock_conversation.call.return_value = _fake_response()
+
+        model = QwenVLModel(api_key="test-key", **init_kwargs)
+        model.generate(text="hi")
+
+        call_kwargs = mock_conversation.call.call_args[1]
+        assert "timeout" not in call_kwargs
+
+        if expect_request_timeout is None:
+            assert "request_timeout" not in call_kwargs
+        else:
+            assert call_kwargs["request_timeout"] == expect_request_timeout


### PR DESCRIPTION
QwenVLModel is the one model class with no timeout knob. Every DashScope call was pinned to the SDK's own 300s default, and passing `timeout=` to the constructor raised a TypeError.

Worth flagging: the fix isn't just "add a timeout kwarg like OpenAIChatModel does." DashScope's `MultiModalConversation.call()` accepts a `timeout=` kwarg but drops it into the request body as an unused parameter; the actual socket timeout only applies through `request_timeout=`. I checked this by patching `HttpRequest.__init__` and confirming `timeout=5.0` never reaches it, while `request_timeout=5.0` does. So the constructor still takes `timeout` for parity with the sibling classes, but `generate()` forwards it as `request_timeout` internally.

I didn't add `max_retries` alongside it. DashScope's HTTP layer for this call has no retry mechanism at all, so a `max_retries` param would be exactly the kind of silent no-op this PR is fixing.

Added tests/models/test_qwen_vl_model.py (didn't exist yet) covering timeout set, unset, and explicit None, each asserting `request_timeout` (never `timeout`) is what reaches the mocked call. Ran the full tests/models/ suite on python 3.11, 57 passed / 3 skipped (integration tests need live keys), black and isort clean.
